### PR TITLE
chore(Dockerfile): Use newer quay.io/deis/base image

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/base:0.2.0
+FROM quay.io/deis/base:0.3.0
 
 COPY bin/steward /bin
 


### PR DESCRIPTION
Reduces image size by a measly 5 MB, but it's always worth it to stay up to date on these things anyway.
