### PR TITLE
chore(CI): Publish images on merge to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
 language: generic
 branches:
   only:
-    - master
+  - master
 cache:
   directories:
-    - vendor
+  - vendor
 services:
-  - docker
+- docker
 sudo: required
 install:
-  - make bootstrap
+- make bootstrap
 script:
-  - make test-cover docker-build
+- make test-cover docker-build
 deploy:
   provider: script
-  script: deploy.sh
+  script: _scripts/deploy.sh
   on:
     branch: master
 

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Build and push Docker images to quay.io.
+#
+
+cd "$(dirname "$0")" || exit 1
+
+export IMAGE_PREFIX=deisci
+docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
+DEIS_REGISTRY=quay.io/ make -C .. docker-build docker-push

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" https://quay.io
-make docker-build docker-push

--- a/manifests/cf-sample-steward.yaml
+++ b/manifests/cf-sample-steward.yaml
@@ -1,0 +1,62 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cf-sample-steward
+  namespace: steward
+  labels:
+    app: cf-sample-steward
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cf-sample-steward
+    spec:
+      containers:
+      - name: cf-sample-steward
+        image: quay.io/krancour/steward:git-74d938e
+        env:
+        - name: CF_BROKER_SCHEME
+          value: "http"
+        - name: CF_BROKER_HOSTNAME
+          value: "10.0.0.153"
+        - name: CF_BROKER_PORT
+          value: "80"
+        - name: CF_BROKER_USERNAME
+          value: "admin"
+        - name: CF_BROKER_PASSWORD
+          value: "password"
+        livenessProbe:
+          exec:
+            command:
+            - /bin/pidof
+            - steward
+          failureThreshold: 3
+          initialDelaySeconds: 50
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 50
+        readinessProbe:
+          exec:
+            command:
+            - /bin/pidof
+            - steward
+          failureThreshold: 3
+          initialDelaySeconds: 50
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 50
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cf-sample-steward
+  namespace: steward
+  labels:
+    app: cf-sample-steward
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: cf-sample-steward

--- a/versioning.mk
+++ b/versioning.mk
@@ -1,4 +1,4 @@
-MUTABLE_VERSION ?= canary
+MUTABLE_VERSION ?= devel
 VERSION ?= git-$(shell git rev-parse --short HEAD)
 IMAGE_PREFIX ?= deis
 


### PR DESCRIPTION
Closes #77 

Also slightly refactors `.travis.yml` since it's preferred in YAML to treat a leading `-` as implying indentation.

Also moves `deploy.sh` into a `_scripts` directory for better parity with Workflow components.

Requires some env vars to be set out-of-band, within Travis.
