### PR TITLE
chore(manifests): Improve readiness and liveness probes

### DIFF
--- a/manifests/steward-template.yaml
+++ b/manifests/steward-template.yaml
@@ -32,20 +32,20 @@ spec:
             - /bin/pidof
             - steward
           failureThreshold: 3
-          initialDelaySeconds: 50
+          initialDelaySeconds: 5
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 50
+          timeoutSeconds: 2
         readinessProbe:
           exec:
             command:
             - /bin/pidof
             - steward
-          failureThreshold: 3
-          initialDelaySeconds: 50
+          failureThreshold: 1
+          initialDelaySeconds: 5
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 50
+          timeoutSeconds: 2
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This container starts pretty fast, but initial delay values on probes were a bit high, which slows things down. This PR corrects that and a few other things-- for instance, the timeout on probes is lowered based on the expected low latency of those probes since they're only executing a trivial command (`pidof`).
