### PR TITLE
chore(mode): Refactor how modes are run

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,10 +7,6 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-const (
-	cfMode = "cf"
-)
-
 type errModeUnsupported struct {
 	mode string
 }
@@ -22,15 +18,6 @@ func (e errModeUnsupported) Error() string {
 type config struct {
 	Mode     string `envconfig:"MODE" default:"cf"`
 	LogLevel string `envconfig:"LOG_LEVEL" default:"info"`
-}
-
-func (c config) validate() error {
-	switch c.Mode {
-	case cfMode:
-	default:
-		return errModeUnsupported{mode: c.Mode}
-	}
-	return nil
 }
 
 func (c config) logLevel() loggo.Level {

--- a/mode/utils/cf_config.go
+++ b/mode/utils/cf_config.go
@@ -1,16 +1,11 @@
-package cf
+package utils
 
 import (
 	"github.com/deis/steward/web"
 	"github.com/kelseyhightower/envconfig"
 )
 
-const (
-	appName = "steward"
-)
-
-// Config is the envconfig-compatible struct for a backing CF service broker
-type Config struct {
+type cfConfig struct {
 	Scheme   string `envconfig:"CF_BROKER_SCHEME" required:"true"`
 	Hostname string `envconfig:"CF_BROKER_HOSTNAME" required:"true"`
 	Port     int    `envconfig:"CF_BROKER_PORT" required:"true"`
@@ -18,16 +13,14 @@ type Config struct {
 	Password string `envconfig:"CF_BROKER_PASSWORD" required:"true"`
 }
 
-// GetConfig gets the
-func GetConfig() (*Config, error) {
-	ret := new(Config)
+func getCfConfig() (*cfConfig, error) {
+	ret := new(cfConfig)
 	if err := envconfig.Process(appName, ret); err != nil {
 		return nil, err
 	}
 	return ret, nil
 }
 
-// BasicAuth returns the basic auth struct that this CF broker config represents
-func (c Config) BasicAuth() *web.BasicAuth {
+func (c cfConfig) basicAuth() *web.BasicAuth {
 	return &web.BasicAuth{Username: c.Username, Password: c.Password}
 }

--- a/mode/utils/cf_errors.go
+++ b/mode/utils/cf_errors.go
@@ -1,0 +1,11 @@
+package utils
+
+import "fmt"
+
+type errGettingCFBrokerConfig struct {
+	Original error
+}
+
+func (e errGettingCFBrokerConfig) Error() string {
+	return fmt.Sprintf("error getting Cloud Foundry broker config: %s", e.Original)
+}

--- a/mode/utils/cf_mode.go
+++ b/mode/utils/cf_mode.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"net/http"
+
+	"github.com/deis/steward/mode"
+	"github.com/deis/steward/mode/cf"
+)
+
+func getCfModeComponents() (mode.Cataloger, *mode.Lifecycler, error) {
+	cfCfg, err := getCfConfig()
+	if err != nil {
+		return nil, nil, errGettingCFBrokerConfig{Original: err}
+	}
+	logger.Infof(
+		"starting in Cloud Foundry mode with hostname %s, port %d, and username %s",
+		cfCfg.Hostname,
+		cfCfg.Port,
+		cfCfg.Username,
+	)
+	cfClient := cf.NewRESTClient(
+		http.DefaultClient,
+		cfCfg.Scheme,
+		cfCfg.Hostname,
+		cfCfg.Port,
+		cfCfg.Username,
+		cfCfg.Password,
+	)
+	cataloger := cf.NewCataloger(cfClient)
+	lifecycler := cf.NewLifecycler(cfClient)
+	return cataloger, lifecycler, nil
+}

--- a/mode/utils/common.go
+++ b/mode/utils/common.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"github.com/juju/loggo"
+)
+
+const (
+	appName = "steward"
+)
+
+var (
+	logger = loggo.GetLogger("mode.utils")
+)

--- a/mode/utils/errors.go
+++ b/mode/utils/errors.go
@@ -1,0 +1,43 @@
+package utils
+
+import "fmt"
+
+type errUnrecognizedMode struct {
+	mode string
+}
+
+func (e errUnrecognizedMode) Error() string {
+	return fmt.Sprintf("Unrecognized mode: %s", e.mode)
+}
+
+type errGettingK8sClient struct {
+	Original error
+}
+
+func (e errGettingK8sClient) Error() string {
+	return fmt.Sprintf("error creating new k8s client: %s", e.Original)
+}
+
+type errPublishingServiceCatalog struct {
+	Original error
+}
+
+func (e errPublishingServiceCatalog) Error() string {
+	return fmt.Sprintf("error publishing service catalog: %s", e.Original)
+}
+
+type errGettingServiceCatalogLookupTable struct {
+	Original error
+}
+
+func (e errGettingServiceCatalogLookupTable) Error() string {
+	return fmt.Sprintf("error getting service catalog lookup table: %s", e.Original)
+}
+
+type errGettingServiceCatalog struct {
+	Original error
+}
+
+func (e errGettingServiceCatalog) Error() string {
+	return fmt.Sprintf("error getting service catalog: %s", e.Original)
+}

--- a/mode/utils/mode_runner_test.go
+++ b/mode/utils/mode_runner_test.go
@@ -1,4 +1,4 @@
-package main
+package utils
 
 import (
 	"errors"


### PR DESCRIPTION
Closes #121 

This doesn't _exactly_ add a `Mode` interface and corresponding factory as #121 was suggesting, but it _does_ eliminate the same code smell that prompted me to create #121.

The short version of what this PR does is it DRYs up the code that "runs" a mode. It generalizes it sufficiently that it is no longer necessary to provide a custom `Run<Mode>Mode()` function with each new mode implementation.
