### PR TITLE
chore(responses): Remove HTTP status code from responses

### DIFF
--- a/k8s/claim/event_actions_test.go
+++ b/k8s/claim/event_actions_test.go
@@ -3,7 +3,6 @@ package claim
 import (
 	"context"
 	"errors"
-	"net/http"
 	"testing"
 	"time"
 
@@ -195,7 +194,6 @@ func TestProcessBindInstanceIDFound(t *testing.T) {
 	catalogLookup := getCatalogFromEvents(evt)
 	binder := &fake.Binder{
 		Res: &mode.BindResponse{
-			Status: http.StatusOK,
 			Creds: mode.JSONObject(map[string]string{
 				"cred1": uuid.New(),
 				"cred2": uuid.New(),

--- a/mode/bind_response.go
+++ b/mode/bind_response.go
@@ -2,6 +2,5 @@ package mode
 
 // BindResponse is the response to a binding request
 type BindResponse struct {
-	Status int
-	Creds  JSONObject
+	Creds JSONObject
 }

--- a/mode/cf/binder.go
+++ b/mode/cf/binder.go
@@ -48,10 +48,7 @@ func (b binder) Bind(instanceID, bindingID string, bindRequest *mode.BindRequest
 		return nil, err
 	}
 	logger.Debugf("got response %+v from backing broker", *resp)
-	return &mode.BindResponse{
-		Status: res.StatusCode,
-		Creds:  resp.Credentials,
-	}, nil
+	return &mode.BindResponse{Creds: resp.Credentials}, nil
 }
 
 // NewBinder creates a new CloudFoundry-broker-backed binder implementation

--- a/mode/cf/deprovisioner.go
+++ b/mode/cf/deprovisioner.go
@@ -41,7 +41,7 @@ func (d deprovisioner) Deprovision(instanceID, serviceID, planID string) (*mode.
 	if err := json.NewDecoder(res.Body).Decode(deproResp); err != nil {
 		return nil, err
 	}
-	return &mode.DeprovisionResponse{Status: res.StatusCode, Operation: deproResp.Operation}, nil
+	return &mode.DeprovisionResponse{Operation: deproResp.Operation}, nil
 }
 
 // NewDeprovisioner creates a new CloudFoundry-broker-backed deprovisioner implementation

--- a/mode/cf/provisioner.go
+++ b/mode/cf/provisioner.go
@@ -41,7 +41,7 @@ func (p provisioner) Provision(instanceID string, pReq *mode.ProvisionRequest) (
 	if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
 		return nil, err
 	}
-	return &mode.ProvisionResponse{Status: res.StatusCode, Operation: resp.Operation}, nil
+	return &mode.ProvisionResponse{Operation: resp.Operation}, nil
 }
 
 // NewProvisioner creates a new CloudFoundry-broker-backed provisioner implementation

--- a/mode/deprovision_response.go
+++ b/mode/deprovision_response.go
@@ -2,6 +2,5 @@ package mode
 
 // DeprovisionResponse contains information about the deprovision operation. See https://docs.cloudfoundry.org/services/api.html#deprovisioning for details on what these fields mean
 type DeprovisionResponse struct {
-	Status    int
 	Operation string
 }

--- a/mode/provision_response.go
+++ b/mode/provision_response.go
@@ -2,6 +2,5 @@ package mode
 
 // ProvisionResponse is the response to a provisioning request
 type ProvisionResponse struct {
-	Status    int
 	Operation string
 }


### PR DESCRIPTION
This removes HTTP status codes from response types. @arschles and I agreed this isn't generally useful and doesn't make sense in the context of all modes.
