### PR TITLE
chore(mode): DRY up response objects

### DIFF
--- a/mode/bind_response.go
+++ b/mode/bind_response.go
@@ -1,6 +1,6 @@
 package mode
 
-// BindResponse is the response to a binding request
+// BindResponse represents a response to a binding request. It is marked with JSON struct tags so that it can be encoded to, and decoded from the CloudFoundry binding response body format. See https://docs.cloudfoundry.org/services/api.html#binding for more details
 type BindResponse struct {
-	Creds JSONObject
+	Creds JSONObject `json:"credentials"`
 }

--- a/mode/cf/binder.go
+++ b/mode/cf/binder.go
@@ -9,16 +9,6 @@ import (
 	"github.com/deis/steward/web"
 )
 
-type bindRequest struct {
-	ServiceID  string          `json:"service_id"`
-	PlanID     string          `json:"plan_id"`
-	Parameters mode.JSONObject `json:"parameters"`
-}
-
-type bindResponse struct {
-	Credentials mode.JSONObject `json:"credentials"`
-}
-
 type binder struct {
 	cl *RESTClient
 }
@@ -43,12 +33,12 @@ func (b binder) Bind(instanceID, bindingID string, bindRequest *mode.BindRequest
 		return nil, web.ErrUnexpectedResponseCode{URL: req.URL.String(), Expected: http.StatusOK, Actual: res.StatusCode}
 	}
 
-	resp := new(bindResponse)
+	resp := new(mode.BindResponse)
 	if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
 		return nil, err
 	}
 	logger.Debugf("got response %+v from backing broker", *resp)
-	return &mode.BindResponse{Creds: resp.Credentials}, nil
+	return resp, nil
 }
 
 // NewBinder creates a new CloudFoundry-broker-backed binder implementation

--- a/mode/cf/cataloger.go
+++ b/mode/cf/cataloger.go
@@ -8,11 +8,6 @@ import (
 	"github.com/deis/steward/web"
 )
 
-// wrapper for a list of services, returned by the backend broker
-type serviceList struct {
-	Services []*mode.Service `json:"services"`
-}
-
 type cataloger struct {
 	cl *RESTClient
 }
@@ -27,7 +22,7 @@ func (c cataloger) List() ([]*mode.Service, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
-	serviceList := new(serviceList)
+	serviceList := new(mode.ServiceList)
 	// TODO: drain the response body to avoid a connection leak
 	if err := json.NewDecoder(res.Body).Decode(serviceList); err != nil {
 		logger.Debugf("error decoding JSON response body from backend CF broker (%s)", err)

--- a/mode/cf/deprovisioner.go
+++ b/mode/cf/deprovisioner.go
@@ -9,10 +9,6 @@ import (
 	"github.com/deis/steward/web"
 )
 
-type backendDeprovisionResp struct {
-	Operation string `json:"operation"`
-}
-
 type deprovisioner struct {
 	cl *RESTClient
 }
@@ -37,11 +33,11 @@ func (d deprovisioner) Deprovision(instanceID string, dReq *mode.DeprovisionRequ
 			Actual:   res.StatusCode,
 		}
 	}
-	deproResp := new(backendDeprovisionResp)
-	if err := json.NewDecoder(res.Body).Decode(deproResp); err != nil {
+	resp := new(mode.DeprovisionResponse)
+	if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
 		return nil, err
 	}
-	return &mode.DeprovisionResponse{Operation: deproResp.Operation}, nil
+	return resp, nil
 }
 
 // NewDeprovisioner creates a new CloudFoundry-broker-backed deprovisioner implementation

--- a/mode/cf/provisioner.go
+++ b/mode/cf/provisioner.go
@@ -9,10 +9,6 @@ import (
 	"github.com/deis/steward/web"
 )
 
-type backendProvisionResp struct {
-	Operation string `json:"operation"`
-}
-
 type provisioner struct {
 	cl *RESTClient
 }
@@ -37,11 +33,11 @@ func (p provisioner) Provision(instanceID string, pReq *mode.ProvisionRequest) (
 			Actual:   res.StatusCode,
 		}
 	}
-	resp := new(backendProvisionResp)
+	resp := new(mode.ProvisionResponse)
 	if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
 		return nil, err
 	}
-	return &mode.ProvisionResponse{Operation: resp.Operation}, nil
+	return resp, nil
 }
 
 // NewProvisioner creates a new CloudFoundry-broker-backed provisioner implementation

--- a/mode/deprovision_response.go
+++ b/mode/deprovision_response.go
@@ -1,6 +1,6 @@
 package mode
 
-// DeprovisionResponse contains information about the deprovision operation. See https://docs.cloudfoundry.org/services/api.html#deprovisioning for details on what these fields mean
+// DeprovisionResponse represents a response to a provisioning request. It is marked with JSON struct tags so that it can be encoded to, and decoded from the CloudFoundry deprovisioning response body format. See https://docs.cloudfoundry.org/services/api.html#deprovisioning for more details
 type DeprovisionResponse struct {
-	Operation string
+	Operation string `json:"operation"`
 }

--- a/mode/provision_response.go
+++ b/mode/provision_response.go
@@ -1,6 +1,6 @@
 package mode
 
-// ProvisionResponse is the response to a provisioning request
+// ProvisionResponse represents a response to a provisioning request. It is marked with JSON struct tags so that it can be encoded to, and decoded from the CloudFoundry provisioning response body format. See https://docs.cloudfoundry.org/services/api.html#provisioning for more details
 type ProvisionResponse struct {
-	Operation string
+	Operation string `json:"operation"`
 }

--- a/mode/service_list.go
+++ b/mode/service_list.go
@@ -1,0 +1,6 @@
+package mode
+
+// ServiceList is a wrapper for a list of services and represents a response from a request to list services provided by a broker. It is marked with JSON struct tags so that it can be encoded to, and decoded from the CloudFoundry catalog list response body format. See https://docs.cloudfoundry.org/services/api.html#catalog-mgmt
+type ServiceList struct {
+	Services []*Service `json:"services"`
+}


### PR DESCRIPTION
This PR kills a few birds with one stone.
1. It DRYs things up a bit and eliminates the need for further DRY exceptions when merging jobs mode work.
2. All `mode.<action>Request` types were already JSON-compatible with the CF broker API, but simply for lack of struct tags, `mode.<action>Response` types were not. Since it seems we are willfully going to use CF-like JSON as the lingua franca of Steward, it makes sense for both request _and_ response objects in Steward's own domain to be JSON-compatible with the CF broker API. To relate this back to no. 1, this further reduces the need for each mode that "speaks" CF (as jobs mode will, for instance) to commit new DRY exceptions for the sake of providing CF JSON-compatible response types.
