### PR TITLE
chore(Makefile): Remove unused LDFLAGS variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ DEV_ENV_PREFIX := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_
 DEV_ENV_CMD ?= ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}
 
 VERSION ?= "dev"
-LDFLAGS := "-s -w -X main.version=${VERSION}"
 BINARY_DEST_DIR := rootfs/bin
 
 all:


### PR DESCRIPTION
We're not actually injecting the version into any variable during linking. This Makefile var is completely unused, so removing it.
