### PR TITLE
chore(build): Upgrade go-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHORT_NAME := steward
 include versioning.mk
 
 REPO_PATH := github.com/deis/${SHORT_NAME}
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.17.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.19.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_PREFIX := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}


### PR DESCRIPTION
@arschles after spending most of the day in dependency hell, I want to upgrade to the latest go-dev image because it has glide v0.12.0-- which gives much, much more descriptive messages when it encounters errors.
